### PR TITLE
PHP cheat sheet: Correct exception_ignore_args

### DIFF
--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -17,7 +17,7 @@ For general PHP codebase security please refer to the two following great guides
 
 Some of following settings need to be adapted to your system, in particular `session.save_path`, `session.cookie_path` (e.g. `/var/www/mysite`), and `session.cookie_domain` (e.g. `ExampleSite.com`).
 
-You should be running a [supported version of PHP](https://www.php.net/supported-versions.php) (as of this writing, 8.1 is the oldest version receiving security support). Review the [core `php.ini` directives](https://www.php.net/manual/ini.core.php) in the PHP Manual for a complete reference on every value in the `php.ini` configuration file.
+You should be running a [supported version of PHP](https://www.php.net/supported-versions.php) (as of this writing, 8.1 is the oldest version receiving security support from PHP, though distribution vendors often provide extended support). Review the [core `php.ini` directives](https://www.php.net/manual/ini.core.php) in the PHP Manual for a complete reference on every value in the `php.ini` configuration file.
 
 You can find a copy of the following values in a [ready-to-go `php.ini` file here](https://github.com/danehrlich1/very-secure-php-ini).
 
@@ -105,7 +105,7 @@ post_max_size           = 20M
 max_execution_time      = 60
 report_memleaks         = On
 html_errors             = Off
-zend.exception_ignore_args = Off
+zend.exception_ignore_args = On
 ```
 
 ### Snuffleupagus


### PR DESCRIPTION
My feedback to https://github.com/OWASP/CheatSheetSeries/pull/1464 wasn't included, hence this PR.

The change to `zend.exception_ignore_args` is crucial.
0/Off (disabled) is the default value, which does nothing, for backwards compatibility.
1/On (enabled) means arguments will be excluded from stack traces, avoiding leaks of sensitive information if stack traces are exposed.
See https://www.php.net/manual/en/ini.core.php#ini.zend.exception-ignore-args

The other change is of lower importance, but matters because vendor support can last a lot longer than support from PHP itself.


Please make sure that for your contribution:

- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #1449